### PR TITLE
disabled clear btn when messages empty

### DIFF
--- a/iife4_navinput.js
+++ b/iife4_navinput.js
@@ -15,12 +15,14 @@ var Chatty = (function(newChatty){
     inputString +=`<button class="btn btn-default">Delete</button></div>`;
     messages.innerHTML += inputString;
     textInput.value = "";
+    clearBtn.disabled = false;
     };
   });
 
   clearBtn.addEventListener("click", function() {
     messages.innerHTML = "";
-  })
+    clearBtn.disabled = true;
+  });
 
 
   return newChatty;


### PR DESCRIPTION
Corrected behavior of clear button to be disabled when user clears messages. Returns functionality when new message is submitted.
